### PR TITLE
Fiks docs for Istio retries

### DIFF
--- a/docs/03-applikasjon-utrulling/03-skiperator/04-api-docs.md
+++ b/docs/03-applikasjon-utrulling/03-skiperator/04-api-docs.md
@@ -1702,9 +1702,9 @@ Default: no timeout<br/>
         <td>false</td>
       </tr><tr>
         <td><b>retryOnHttpResponseCodes</b></td>
-        <td>[]int or string</td>
+        <td>[]string or int</td>
         <td>
-          RetryOnHttpResponseCodes HTTP response codes that should trigger a retry. A typical value is [503].
+          RetryOnHttpResponseCodes HTTP response codes that should trigger a retry. A typical value is ['503'].
 You may also use 5xx and retriable-4xx (only 409).<br/>
         </td>
         <td>false</td>


### PR DESCRIPTION
Forsøkte `'5xx'` og fikk feil i Argo. `['5xx']` fungerte, så vil tru det er slik, også ved bruk av `xx`