### PR TITLE
Lag til docs side for skipctl med basic info fra repo

### DIFF
--- a/docs/03-applikasjon-utrulling/05-skipctl/01-get-started.md
+++ b/docs/03-applikasjon-utrulling/05-skipctl/01-get-started.md
@@ -1,0 +1,12 @@
+# Kom i gang
+
+## Installasjon
+
+Last ned [siste versjon](https://github.com/kartverket/skipctl/releases) eller bruk det medfølgende Docker-imaget (hovedsakelig for å kjøre en server).
+
+### Bruk Homebrew
+
+```shell
+brew tap kartverket/taps && \
+brew install skipctl
+```

--- a/docs/03-applikasjon-utrulling/05-skipctl/02-network-troubleshooting.md
+++ b/docs/03-applikasjon-utrulling/05-skipctl/02-network-troubleshooting.md
@@ -1,0 +1,22 @@
+# Nettverkstesting
+
+
+## Bruk
+
+De ulike `test`-kommandoene vil kjøres mot en API-server. Kjør `skipctl test ping --api-server=something` for å få en liste over støttede API-servernavn.
+En API-server representerer et sted som kan kjøre tester fra sitt perspektiv. All kommunikasjon med API-servere er kryptert over TLS.
+
+> :exclamation: Før du kjører noen kommandoer, må du sørge for å være autentisert først (`gcloud auth application-default login`).
+
+
+### Ping
+
+```shell
+skipctl test ping --hostname=example.com --api-server=myApiServer
+```
+
+### Port probe
+
+```shell
+skipctl test probe --hostname=example.com --port=1521 --api-server=myApiServer
+```

--- a/docs/03-applikasjon-utrulling/05-skipctl/index.md
+++ b/docs/03-applikasjon-utrulling/05-skipctl/index.md
@@ -1,0 +1,8 @@
+# 🎮 Skip CTL
+
+**Skipctl** er et kommandolinjeverktøy for utvikling med SKIP.
+Verktøyet gir deg enkle kommandoer for å teste SKIP-miljøer direkte fra terminalen.
+For øyeblikket er testing av ping og probe tilgjengelig.
+
+
+Se [repoet på GitHub](https://github.com/kartverket/skipctl) for mer informasjon.


### PR DESCRIPTION
# Laget skipctl docs ✍️

La til en seksjon i skipdocs om skipctl

Vi kommer med oppdateringer til skipctl og tenkte å oppdatere docs underveis så da
trenger de et sted å være.

Her er bare lagt inn litt basic info fra repo om installering og nåværende funksjonalitet