### PR TITLE
🔒add chainguard spesification for argokit

### DIFF
--- a/.github/chainguard/argokit.sts.yaml
+++ b/.github/chainguard/argokit.sts.yaml
@@ -5,4 +5,4 @@ subject: repo:kartverket\/argokit:ref:refs/heads/(main|updated-documentation)
 
 permissions:
   contents: write
-  pull-requests: write
+  pull_requests: write

--- a/.github/chainguard/argokit.sts.yaml
+++ b/.github/chainguard/argokit.sts.yaml
@@ -5,3 +5,4 @@ subject: repo:kartverket\/argokit:ref:refs/heads/main
 
 permissions:
   contents: write
+  pull-requests: write

--- a/.github/chainguard/argokit.sts.yaml
+++ b/.github/chainguard/argokit.sts.yaml
@@ -1,7 +1,7 @@
 # Permissions for argokit to create PRs in skip.kartverket.no
 
 issuer: https://token.actions.githubusercontent.com
-subject: repo:kartverket\/argokit:ref:refs/heads/main
+subject: repo:kartverket\/argokit:ref:refs/heads/(main|updated-documentation)
 
 permissions:
   contents: write

--- a/.github/chainguard/argokit.sts.yaml
+++ b/.github/chainguard/argokit.sts.yaml
@@ -1,0 +1,7 @@
+# Permissions for argokit to create PRs in skip.kartverket.no
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:kartverket\/argokit:ref:refs/heads/main
+
+permissions:
+  contents: write


### PR DESCRIPTION
In order to create automatic PRs from argokit readme.md updates into skip.kartverket.no argokit docs to keep them in sync