### PR TITLE
[SKIP-1793] add mise.toml

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]


### PR DESCRIPTION
fix netlify warning

```
10:31:01 AM: mise WARN  deprecated [idiomatic_version_file_enable_tools]:
10:31:01 AM: Idiomatic version files like /opt/build/repo/.nvmrc are currently enabled by default. However, this will change in mise 2025.10.0 to instead default to disabled.
10:31:01 AM: You can remove this warning by explicitly enabling idiomatic version files for node with:
10:31:01 AM:     mise settings add idiomatic_version_file_enable_tools node
10:31:01 AM: You can disable idiomatic version files with:
10:31:01 AM:     mise settings add idiomatic_version_file_enable_tools "[]"
10:31:01 AM: See https://github.com/jdx/mise/discussions/4345 for more information.
```