### PR TITLE
remove backslash

### DIFF
--- a/.github/chainguard/argokit.sts.yaml
+++ b/.github/chainguard/argokit.sts.yaml
@@ -1,7 +1,7 @@
 # Permissions for argokit to create PRs in skip.kartverket.no
 
 issuer: https://token.actions.githubusercontent.com
-subject: repo:kartverket\/argokit:ref:refs/heads/(main|updated-documentation)
+subject: repo:kartverket/argokit:ref:refs/heads/(main|updated-documentation)
 
 permissions:
   contents: write


### PR DESCRIPTION
Debugging sts from external workflow with the error message

```
Error: trust policy: subject "repo:kartverket/argokit:ref:refs/heads/updated-documentation" did not match "repo:kartverket\\/argokit:ref:refs/heads/(main|updated-documentation)"
```


regex did not match, trying to remove the backslash

