### PR TITLE
fix: typo in word `Plattform`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = themes.dracula;
 (
   module.exports = {
     title: "SKIP",
-    tagline: "Statens Kartverks Infrastrukturplatform",
+    tagline: "Statens Kartverks Infrastrukturplattform",
     url: "https://skip.kartverket.no",
     baseUrl: "/",
     projectName: 'skip-docs',

--- a/src/components/HomepageFeatures.js
+++ b/src/components/HomepageFeatures.js
@@ -5,7 +5,7 @@ import styles from './HomepageFeatures.module.css';
 
 const FeatureList = [
   {
-    title: 'Fremtidsrettet platform',
+    title: 'Fremtidsrettet plattform',
     Svg: require('../../static/img/undraw_code_review.svg').default,
     description: (
       <>
@@ -39,7 +39,7 @@ const FeatureList = [
     Svg: require('../../static/img/undraw_programmer.svg').default,
     description: (
       <>
-        Platformen vil i bakgrunnen sørge for at applikasjonen skalerer opp ved
+        Plattformen vil i bakgrunnen sørge for at applikasjonen skalerer opp ved
         mye traffikk og ned når det ikke lenger er nødvendig.
         I tillegg sørger den for at applikasjonene restartes ved ustabilitet og
         gir deg data og metrikker til å overvåke tjenesten din.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -54,8 +54,8 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title="SKIP – Statens Kartverks Infrastrukturplatform"
-      description="Statens Kartverks Infrastrukturplatform">
+      title="SKIP – Statens Kartverks Infrastrukturplattform"
+      description="Statens Kartverks Infrastrukturplattform">
       <Head>
         <html lang="no" />
       </Head>


### PR DESCRIPTION
Forsiden til SKIP sin dokumentasjon brukte den engelske stavemåten på ordet `Plattform`