### PR TITLE
Update link and add release tag for build-and-push-opa-bundle workflow 

### DIFF
--- a/docs/08-tilgangsstyring/05-finkornet-autorisasjon/04-opa-pa-skip.mdx
+++ b/docs/08-tilgangsstyring/05-finkornet-autorisasjon/04-opa-pa-skip.mdx
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   build:
-    uses: kartverket/github-workflows/.github/workflows/build-and-push-opa-bundle.yml@<commit-sha>
+    uses: kartverket/github-workflows/.github/workflows/build-and-push-opa-bundle.yml@<release tag>
     with:
       # artifact-name (**påkrevd**) er navnet på det resulterende artefakten i GHCR (uten tag).
       # Den er nødt til å starte med `ghcr.io/kartverket/<repo>`.

--- a/docs/08-tilgangsstyring/05-finkornet-autorisasjon/04-opa-pa-skip.mdx
+++ b/docs/08-tilgangsstyring/05-finkornet-autorisasjon/04-opa-pa-skip.mdx
@@ -14,7 +14,7 @@ bundles.
 
 ## Bygge bundle i GitHub Actions
 
-Team Tilgangsstyring har lagd workflowen `kartverket/github-workflows/.github/workflows/build-and-push-opa-bundle.yml`,
+Team Tilgangsstyring har lagd workflowen [kartverket/github-workflows/.github/workflows/build-and-push-opa-bundle.yml](https://github.com/kartverket/github-workflows#build-and-push-opa-bundle),
 som gjør det enkelt for deg å bygge og publisere OPA-bundler til GHCR i GitHub Actions.
 
 


### PR DESCRIPTION
Adding link to the README for build-and-push-opa-bundle. Also specify that a release tag can be used as immutable tags are used in kartverket/github-workflows.