### PR TITLE
Add Kartverket agent

### DIFF
--- a/.github/agents/kartverket-standard.agent.md
+++ b/.github/agents/kartverket-standard.agent.md
@@ -1,0 +1,27 @@
+---
+name: kartverket-standard
+description: Kartverkets standardkonfigurasjon for KI-assistanse.
+tools: [
+    # VSCode
+    "read",
+    "edit",
+    "search",
+    "web",
+    "todo",
+    # JetBrains (IntelliJ, GoLand, Rider, PyCharm, etc.)
+    "insert_edit_into_file",
+    "replace_string_in_file",
+    "create_file",
+    "apply_patch",
+    "open_file",
+    "ask_questions",
+    "get_errors",
+    "list_dir",
+    "read_file",
+    "file_search",
+    "grep_search",
+    "validate_cves",
+  ]
+---
+
+Kartverkets standardkonfigurasjon for KI-assistanse.


### PR DESCRIPTION
Kartverket requires employees to use a specific Copilot agent without terminal or subagent access. When the Copilot IDE plugin is used, this agent should always be active.