### PR TITLE
Add offline_access docs for longer user sessions

### DIFF
--- a/docs/08-tilgangsstyring/03-innlogging/index.mdx
+++ b/docs/08-tilgangsstyring/03-innlogging/index.mdx
@@ -6,6 +6,10 @@ kryptert med en hemmelighet kun din applikasjon har tilgang til.
 
 [Les mer om innlogging og sesjonshåndtering i Ztoperator-dokumentasjonen](../08-ztoperator/index.mdx#-innlogging-og-utlogging-med-ztoperator)
 
+For applikasjoner som trenger lengre brukersesjoner uten re-autentisering, kan scopet `offline_access` legges til i
+`AuthPolicy`-feltet `spec.autoLogin.scopes` for å aktivere støtte for refresh-tokens.
+[Les mer om bruk av offline_access og refresh-tokens i Ztoperator-dokumentasjonen](../08-ztoperator/index.mdx#lengre-brukersesjoner-med-offline_access-og-refresh-tokens).
+
 ## Hvordan fungerer innlogging med Ztoperator
 SKIP-plattformen bruker et _service mesh_, kalt Istio. Istio gjør at det kjører en `istio-proxy`-sidecar sammen med
 applikasjonen din i samme Kubernetes-pod. Når du oppretter en `AuthPolicy`-ressurs for applikasjonen din med

--- a/docs/08-tilgangsstyring/08-ztoperator/index.mdx
+++ b/docs/08-tilgangsstyring/08-ztoperator/index.mdx
@@ -125,6 +125,55 @@ spec:
         - application: myjob-skipjob
 ```
 
+
+### Lengre brukersesjoner med `offline_access` og refresh-tokens
+
+Som standard vil en brukersesjon utløpe når access-tokenet fra identitetstilbyderen utløper. For applikasjoner som
+krever lengre sesjoner uten at brukeren skal måtte logge inn på nytt, kan scopet `offline_access` legges til i
+`spec.autoLogin.scopes`. Dette ber identitetstilbyderen om å utstede et **refresh-token** i tillegg til access-tokenet.
+
+Ztoperator vil automatisk bruke refresh-tokenet til å hente nye access-tokens i bakgrunnen når det eksisterende
+utløper, slik at brukeren holdes innlogget uten avbrudd.
+
+:::caution[Sikkerhetshensyn]
+Refresh-tokens gir langvarig tilgang, som kan ha konsekvenser og muliggjøre misbruk. Sørg for at:
+- Du kun bruker `offline_access` der det er et reelt behov for lengre sesjoner.
+- Utlogging (`logoutPath`) er konfigurert slik at refresh-tokenet tilbakekalles hos identitetstilbyderen ved utlogging (RP-initiated logout).
+:::
+
+#### Konfigurere `offline_access` i AuthPolicy
+
+Legg til `offline_access` i `spec.autoLogin.scopes`-listen:
+
+```yaml title="AuthPolicy med offline_access for lengre sesjoner"
+apiVersion: ztoperator.kartverket.no/v1alpha1
+kind: AuthPolicy
+metadata:
+  name: min-authpolicy
+spec:
+  autoLogin:
+    enabled: true
+    logoutPath: /logout
+    redirectPath: /oauth2/callback
+    scopes:
+//diff-add-start
+      - offline_access
+//diff-add-end
+      ...
+  ...
+```
+
+#### Hva skjer i bakgrunnen?
+
+Når `offline_access` er inkludert i scopes, vil flyten se slik ut:
+
+1. Brukeren logger inn og identitetstilbyderen returnerer både et **access-token** og et **refresh-token**.
+2. Ztoperator lagrer refresh-tokenet kryptert i session-cookien på klientsiden.
+3. Når access-tokenet nærmer seg utløp, bruker Ztoperator automatisk refresh-tokenet til å hente et nytt access-token
+via [token refresh-flyten (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749#section-6) – uten at brukeren
+merker noe.
+4. Sesjonen varer inntil refresh-tokenet selv utløper eller trekkes tilbake av identitetstilbyderen.
+
 ## 🎬 Tutorials
 
 I denne docsen finner du en rekke tutorials på hvordan du tar i bruk Ztoperator for å beskytte en applikasjon på SKIP.

--- a/docs/08-tilgangsstyring/08-ztoperator/index.mdx
+++ b/docs/08-tilgangsstyring/08-ztoperator/index.mdx
@@ -136,14 +136,11 @@ Ztoperator vil automatisk bruke refresh-tokenet til å hente nye access-tokens i
 utløper, slik at brukeren holdes innlogget uten avbrudd.
 
 :::caution[Sikkerhetshensyn]
-Refresh-tokens gir langvarig tilgang, som kan ha konsekvenser og muliggjøre misbruk. Sørg for at:
-- Du kun bruker `offline_access` der det er et reelt behov for lengre sesjoner.
-- Utlogging (`logoutPath`) er konfigurert slik at refresh-tokenet tilbakekalles hos identitetstilbyderen ved utlogging (RP-initiated logout).
+Refresh-tokens gir langvarig tilgang, som kan ha konsekvenser og muliggjøre misbruk. Sørg for at
+du kun bruker `offline_access` når det er et reelt behov for lengre sesjoner.
 :::
 
-#### Konfigurere `offline_access` i AuthPolicy
-
-Legg til `offline_access` i `spec.autoLogin.scopes`-listen:
+Du kan ta i bruk `offline_access` i din `AuthPolicy` ved å legge det til i `spec.autoLogin.scopes`-listen:
 
 ```yaml title="AuthPolicy med offline_access for lengre sesjoner"
 apiVersion: ztoperator.kartverket.no/v1alpha1
@@ -163,15 +160,12 @@ spec:
   ...
 ```
 
-#### Hva skjer i bakgrunnen?
-
 Når `offline_access` er inkludert i scopes, vil flyten se slik ut:
 
 1. Brukeren logger inn og identitetstilbyderen returnerer både et **access-token** og et **refresh-token**.
 2. Ztoperator lagrer refresh-tokenet kryptert i session-cookien på klientsiden.
-3. Når access-tokenet nærmer seg utløp, bruker Ztoperator automatisk refresh-tokenet til å hente et nytt access-token
-via [token refresh-flyten (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749#section-6) – uten at brukeren
-merker noe.
+3. Når access-tokenet er utløpt eller ikke lenger tilgjengelig, bruker Ztoperator automatisk refresh-tokenet til å hente et nytt access-token
+via [token refresh-flyten (RFC 6749)](https://datatracker.ietf.org/doc/html/rfc6749#section-6) – uten at brukeren merker noe.
 4. Sesjonen varer inntil refresh-tokenet selv utløper eller trekkes tilbake av identitetstilbyderen.
 
 ## 🎬 Tutorials


### PR DESCRIPTION
Important to note that the use of refresh tokens is not risk free from the user's point of view. This is reflected in the docs.